### PR TITLE
Update turtlesvg.py

### DIFF
--- a/turtlesvg.py
+++ b/turtlesvg.py
@@ -533,6 +533,8 @@ class Path(Renderable):
                 self.lineto([initial], t, False)
                 # Not technically correct, but turtle can't handle self-intersecting paths properly
                 t.svg_end()
+                if i + 1 < len(parts):
+                    style.fill = '#FFFFFF'
                 style.apply(t, matrix)
             elif command == 'L' or command == 'l':
                 points, j = self.getpoints(parts, i)
@@ -767,6 +769,8 @@ class TurtleSVG(object):
 def demo(file, width=None):
     import turtle
     t = turtle.Turtle()
+    #speed 控制速度
+    t.screen.delay(0)
     a = TurtleSVG(file)
     a.render(t, width=width)
     turtle.mainloop()


### PR DESCRIPTION
Similar to a ring or other type of inner-blank polygon
I did not hava a good way to deal with it
Can only be drawn outwards first, then interior painted white, 
But this causes the order of the layers to be correct
类似与圆环或者其他类型的 内空多边形
暂时没有想到什么好的办法处理
只能先画出来 再把内部画为白色, 但是这就导致了图层的顺序问题
exsample:
![exsample](http://152.32.226.71/logo.svg)